### PR TITLE
Fix issue that check if complex object or not.

### DIFF
--- a/types.go
+++ b/types.go
@@ -71,12 +71,21 @@ func GetComplexObjectInfo(val interface{}) (interface{}, string, bool) {
 		if val == "" {
 			return nil, "", false
 		} else {
-			complexObject := &legacyData.ComplexObject{}
-			err := json.Unmarshal([]byte(t), complexObject)
+			var complexMap map[string]interface{}
+			err := json.Unmarshal([]byte(t), &complexMap)
 			if err != nil {
 				return nil, "", false
 			}
-			return complexObject.Value, complexObject.Metadata, true
+
+			v, hasVal := complexMap["value"]
+			mdI, hasMd := complexMap["metadata"]
+			md := ""
+			if hasMd {
+				md, hasMd = mdI.(string)
+			}
+			if hasVal && hasMd {
+				return v, md, true
+			}
 		}
 	case map[string]interface{}:
 		v, hasVal := t["value"]

--- a/types_test.go
+++ b/types_test.go
@@ -1,0 +1,30 @@
+package legacybridge
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGetComplexObjectInfo(t *testing.T) {
+
+	cpx := `{"value":"123", "metadata":"medatat"}`
+	v, metadata, ok := GetComplexObjectInfo(cpx)
+	assert.True(t, ok)
+	assert.Equal(t, "medatat", metadata)
+	assert.Equal(t, "123", v)
+
+	cpx = `{"value":"123"}`
+	v, metadata, ok = GetComplexObjectInfo(cpx)
+	assert.False(t, ok)
+
+	cpx = `{"metadata":"123"}`
+	v, metadata, ok = GetComplexObjectInfo(cpx)
+	assert.False(t, ok)
+
+	cpx = `{"value":"", "metadata":""}`
+	v, metadata, ok = GetComplexObjectInfo(cpx)
+	assert.True(t, ok)
+	assert.Equal(t, "", metadata)
+	assert.Equal(t, "", v)
+
+}


### PR DESCRIPTION
json. Unmarshal will not throw an error when it on a json data.  

So actually it is not a complex object but  it takes as complex object because there is no error return

Fix the issue to make sure both value and metadata are existed to make sure it is complex_object.